### PR TITLE
バッファのハンドルをオープンにしたままだったのでクローズを追加した。

### DIFF
--- a/host_if_minimal/hostif_main.c
+++ b/host_if_minimal/hostif_main.c
@@ -165,6 +165,9 @@ static void *hostif_loopback(void *arg)
         }
     }
 
+  close(rfd);
+  close(wfd);
+
   return NULL;
 }
 
@@ -240,6 +243,9 @@ static void *hostif_updater(void *arg)
       sleep(1);
     }
 #endif
+
+  close(wfd3);
+  close(wfd2);
 
   return NULL;
 }


### PR DESCRIPTION
ファイルハンドルをopenしたままクローズしていない。
具体的にはつぎの箇所。

hostif_main.c

hostif_loopback
rfd : read device of BUFFER0
wfd : write device of BUFFER1

hostif_updater
 wfd2 : write device of BUFFER2
 wfd3 : write device of BUFFER3
